### PR TITLE
feat(visits): 訪問記録CRUD API (Issue #15)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from "./auth";
 import { SalespersonsModule } from "./salespersons";
 import { CustomersModule } from "./customers";
 import { ReportsModule } from "./reports";
+import { VisitsModule } from "./visits";
 import { GlobalExceptionFilter } from "./common/filters";
 import { TransformResponseInterceptor } from "./common/interceptors";
 
@@ -26,6 +27,8 @@ import { TransformResponseInterceptor } from "./common/interceptors";
     CustomersModule,
     // 日報モジュール
     ReportsModule,
+    // 訪問記録モジュール
+    VisitsModule,
   ],
   controllers: [],
   providers: [

--- a/src/visits/dto/create-visit.dto.ts
+++ b/src/visits/dto/create-visit.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsInt, IsNotEmpty, IsOptional, IsString, Matches, MaxLength, Min } from "class-validator";
+
+/**
+ * 訪問記録作成DTO
+ */
+export class CreateVisitDto {
+  @ApiProperty({ description: "顧客ID", example: 1 })
+  @IsInt({ message: "顧客IDは整数で指定してください" })
+  @Min(1, { message: "顧客IDは1以上の値を指定してください" })
+  customer_id!: number;
+
+  @ApiPropertyOptional({
+    description: "訪問時刻（HH:mm形式）",
+    example: "10:00",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: "訪問時刻はHH:mm形式で指定してください",
+  })
+  visit_time?: string;
+
+  @ApiPropertyOptional({
+    description: "訪問目的",
+    example: "定期訪問",
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100, { message: "訪問目的は100文字以内で入力してください" })
+  visit_purpose?: string;
+
+  @ApiProperty({
+    description: "訪問内容",
+    example: "新製品の提案を行った。",
+  })
+  @IsString({ message: "訪問内容は文字列で指定してください" })
+  @IsNotEmpty({ message: "訪問内容は必須です" })
+  visit_content!: string;
+
+  @ApiPropertyOptional({
+    description: "結果",
+    example: "次回見積提出予定",
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100, { message: "結果は100文字以内で入力してください" })
+  result?: string;
+}

--- a/src/visits/dto/index.ts
+++ b/src/visits/dto/index.ts
@@ -1,0 +1,3 @@
+export * from "./create-visit.dto";
+export * from "./update-visit.dto";
+export * from "./visit-response.dto";

--- a/src/visits/dto/update-visit.dto.ts
+++ b/src/visits/dto/update-visit.dto.ts
@@ -1,0 +1,52 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsInt, IsOptional, IsString, Matches, MaxLength, Min } from "class-validator";
+
+/**
+ * 訪問記録更新DTO
+ */
+export class UpdateVisitDto {
+  @ApiPropertyOptional({ description: "顧客ID", example: 1 })
+  @IsOptional()
+  @IsInt({ message: "顧客IDは整数で指定してください" })
+  @Min(1, { message: "顧客IDは1以上の値を指定してください" })
+  customer_id?: number;
+
+  @ApiPropertyOptional({
+    description: "訪問時刻（HH:mm形式）",
+    example: "10:00",
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: "訪問時刻はHH:mm形式で指定してください",
+  })
+  visit_time?: string | null;
+
+  @ApiPropertyOptional({
+    description: "訪問目的",
+    example: "定期訪問",
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100, { message: "訪問目的は100文字以内で入力してください" })
+  visit_purpose?: string | null;
+
+  @ApiPropertyOptional({
+    description: "訪問内容",
+    example: "新製品の提案を行った。",
+  })
+  @IsOptional()
+  @IsString({ message: "訪問内容は文字列で指定してください" })
+  visit_content?: string;
+
+  @ApiPropertyOptional({
+    description: "結果",
+    example: "次回見積提出予定",
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100, { message: "結果は100文字以内で入力してください" })
+  result?: string | null;
+}

--- a/src/visits/dto/visit-response.dto.ts
+++ b/src/visits/dto/visit-response.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+/**
+ * 顧客情報DTO
+ */
+export class VisitCustomerDto {
+  @ApiProperty({ description: "顧客ID", example: 1 })
+  customer_id!: number;
+
+  @ApiProperty({ description: "顧客名", example: "株式会社ABC" })
+  customer_name!: string;
+}
+
+/**
+ * 訪問記録DTO
+ */
+export class VisitDto {
+  @ApiProperty({ description: "訪問ID", example: 1 })
+  visit_id!: number;
+
+  @ApiProperty({ description: "顧客情報", type: VisitCustomerDto })
+  customer!: VisitCustomerDto;
+
+  @ApiPropertyOptional({ description: "訪問時刻", example: "10:00" })
+  visit_time!: string | null;
+
+  @ApiPropertyOptional({ description: "訪問目的", example: "定期訪問" })
+  visit_purpose!: string | null;
+
+  @ApiProperty({ description: "訪問内容", example: "新製品の提案を行った。" })
+  visit_content!: string;
+
+  @ApiPropertyOptional({ description: "結果", example: "次回見積提出予定" })
+  result!: string | null;
+
+  @ApiProperty({ description: "作成日時", example: "2026-02-15T09:00:00.000Z" })
+  created_at!: string;
+
+  @ApiProperty({ description: "更新日時", example: "2026-02-15T09:00:00.000Z" })
+  updated_at!: string;
+}
+
+/**
+ * 訪問記録一覧レスポンスDTO
+ */
+export class VisitListResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "訪問記録一覧", type: [VisitDto] })
+  data!: VisitDto[];
+}
+
+/**
+ * 訪問記録詳細レスポンスDTO
+ */
+export class VisitDetailResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "訪問記録", type: VisitDto })
+  data!: VisitDto;
+}
+
+/**
+ * 訪問記録削除レスポンスDTO
+ */
+export class VisitDeleteResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "メッセージ", example: "訪問記録を削除しました" })
+  message!: string;
+}

--- a/src/visits/index.ts
+++ b/src/visits/index.ts
@@ -1,0 +1,3 @@
+export * from "./visits.module";
+export * from "./visits.service";
+export * from "./visits.controller";

--- a/src/visits/visits.controller.spec.ts
+++ b/src/visits/visits.controller.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VisitsController } from "./visits.controller";
+import type { VisitsService } from "./visits.service";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("VisitsController", () => {
+  let visitsController: VisitsController;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockVisitsService = {
+    findAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    visitsController = new VisitsController(mockVisitsService as unknown as VisitsService);
+  });
+
+  describe("findAll", () => {
+    it("訪問記録一覧を取得できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: [
+          {
+            visit_id: 1,
+            customer: {
+              customer_id: 1,
+              customer_name: "株式会社ABC",
+            },
+            visit_time: "10:00",
+            visit_purpose: "定期訪問",
+            visit_content: "新製品の提案を行った。",
+            result: "次回見積提出予定",
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      };
+
+      mockVisitsService.findAll.mockResolvedValue(mockResponse);
+
+      const result = await visitsController.findAll(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockVisitsService.findAll).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+
+  describe("create", () => {
+    it("VST-001: 訪問記録を登録できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          visit_id: 1,
+          customer: {
+            customer_id: 1,
+            customer_name: "株式会社ABC",
+          },
+          visit_time: "10:00",
+          visit_purpose: "定期訪問",
+          visit_content: "新製品の提案を行った。",
+          result: "次回見積提出予定",
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T09:00:00.000Z",
+        },
+      };
+
+      mockVisitsService.create.mockResolvedValue(mockResponse);
+
+      const dto = {
+        customer_id: 1,
+        visit_time: "10:00",
+        visit_purpose: "定期訪問",
+        visit_content: "新製品の提案を行った。",
+        result: "次回見積提出予定",
+      };
+
+      const result = await visitsController.create(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockVisitsService.create).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("update", () => {
+    it("VST-010: 訪問記録を更新できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          visit_id: 1,
+          customer: {
+            customer_id: 2,
+            customer_name: "株式会社XYZ",
+          },
+          visit_time: "14:00",
+          visit_purpose: "緊急訪問",
+          visit_content: "クレーム対応を行った。",
+          result: "解決済み",
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T15:00:00.000Z",
+        },
+      };
+
+      mockVisitsService.update.mockResolvedValue(mockResponse);
+
+      const dto = {
+        customer_id: 2,
+        visit_time: "14:00",
+        visit_purpose: "緊急訪問",
+        visit_content: "クレーム対応を行った。",
+        result: "解決済み",
+      };
+
+      const result = await visitsController.update(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockVisitsService.update).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("remove", () => {
+    it("VST-013: 訪問記録を削除できる", async () => {
+      const mockResponse = {
+        success: true,
+        message: "訪問記録を削除しました",
+      };
+
+      mockVisitsService.remove.mockResolvedValue(mockResponse);
+
+      const result = await visitsController.remove(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockVisitsService.remove).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+});

--- a/src/visits/visits.controller.ts
+++ b/src/visits/visits.controller.ts
@@ -1,0 +1,191 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  Request,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { VisitsService } from "./visits.service";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS validation requires runtime class reference
+import {
+  CreateVisitDto,
+  UpdateVisitDto,
+  VisitListResponseDto,
+  VisitDetailResponseDto,
+  VisitDeleteResponseDto,
+} from "./dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+@ApiTags("訪問記録")
+@Controller()
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class VisitsController {
+  constructor(private readonly visitsService: VisitsService) {}
+
+  /**
+   * 訪問記録一覧取得
+   */
+  @Get("reports/:reportId/visits")
+  @ApiOperation({
+    summary: "訪問記録一覧取得",
+    description: "指定した日報の訪問記録一覧を取得する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "取得成功",
+    type: VisitListResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報にアクセス）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  async findAll(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<VisitListResponseDto> {
+    return this.visitsService.findAll(reportId, req.user);
+  }
+
+  /**
+   * 訪問記録登録
+   */
+  @Post("reports/:reportId/visits")
+  @ApiOperation({
+    summary: "訪問記録登録",
+    description: "指定した日報に訪問記録を登録する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 201,
+    description: "登録成功",
+    type: VisitDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報への追加、または提出済み日報への追加）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（顧客IDが存在しない等）",
+  })
+  async create(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Body() dto: CreateVisitDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<VisitDetailResponseDto> {
+    return this.visitsService.create(reportId, dto, req.user);
+  }
+
+  /**
+   * 訪問記録更新
+   */
+  @Put("visits/:id")
+  @ApiOperation({
+    summary: "訪問記録更新",
+    description: "指定した訪問記録を更新する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "訪問ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "更新成功",
+    type: VisitDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の訪問記録の更新、または提出済み日報の訪問記録の更新）",
+  })
+  @ApiNotFoundResponse({
+    description: "訪問記録が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（顧客IDが存在しない等）",
+  })
+  async update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: UpdateVisitDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<VisitDetailResponseDto> {
+    return this.visitsService.update(id, dto, req.user);
+  }
+
+  /**
+   * 訪問記録削除
+   */
+  @Delete("visits/:id")
+  @ApiOperation({
+    summary: "訪問記録削除",
+    description: "指定した訪問記録を削除する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "訪問ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "削除成功",
+    type: VisitDeleteResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の訪問記録の削除、または提出済み日報の訪問記録の削除）",
+  })
+  @ApiNotFoundResponse({
+    description: "訪問記録が見つからない",
+  })
+  async remove(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<VisitDeleteResponseDto> {
+    return this.visitsService.remove(id, req.user);
+  }
+}

--- a/src/visits/visits.module.ts
+++ b/src/visits/visits.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { VisitsController } from "./visits.controller";
+import { VisitsService } from "./visits.service";
+
+@Module({
+  controllers: [VisitsController],
+  providers: [VisitsService],
+  exports: [VisitsService],
+})
+export class VisitsModule {}

--- a/src/visits/visits.service.spec.ts
+++ b/src/visits/visits.service.spec.ts
@@ -1,0 +1,469 @@
+import {
+  NotFoundException,
+  ForbiddenException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VisitsService } from "./visits.service";
+import type { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("VisitsService", () => {
+  let visitsService: VisitsService;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockAdminUser: AuthenticatedUser = {
+    id: 99,
+    email: "admin@example.com",
+    name: "Admin",
+    role: "admin" as const,
+  };
+
+  const mockPrismaService = {
+    dailyReport: {
+      findUnique: vi.fn(),
+    },
+    visit: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    customer: {
+      findUnique: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    visitsService = new VisitsService(mockPrismaService as unknown as PrismaService);
+  });
+
+  describe("findAll", () => {
+    it("日報の訪問記録一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockVisits = [
+        {
+          id: 1,
+          visitTime: new Date("1970-01-01T10:00:00Z"),
+          visitPurpose: "定期訪問",
+          visitContent: "新製品の提案を行った。",
+          result: "次回見積提出予定",
+          createdAt: new Date("2026-02-15T09:00:00Z"),
+          updatedAt: new Date("2026-02-15T09:00:00Z"),
+          customer: {
+            id: 1,
+            customerName: "株式会社ABC",
+          },
+        },
+      ];
+
+      mockPrismaService.visit.findMany.mockResolvedValue(mockVisits);
+
+      const result = await visitsService.findAll(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [
+          {
+            visit_id: 1,
+            customer: {
+              customer_id: 1,
+              customer_name: "株式会社ABC",
+            },
+            visit_time: "10:00",
+            visit_purpose: "定期訪問",
+            visit_content: "新製品の提案を行った。",
+            result: "次回見積提出予定",
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      });
+    });
+
+    it("存在しない日報IDで404エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue(null);
+
+      await expect(visitsService.findAll(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it("他人の日報へのアクセスで403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(visitsService.findAll(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("create", () => {
+    // VST-001: 正常系 - 訪問記録を登録できること
+    it("VST-001: 訪問記録を登録できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      mockPrismaService.customer.findUnique.mockResolvedValue({ id: 1 });
+
+      const mockCreatedVisit = {
+        id: 1,
+        visitTime: new Date("1970-01-01T10:00:00Z"),
+        visitPurpose: "定期訪問",
+        visitContent: "新製品の提案を行った。",
+        result: "次回見積提出予定",
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        customer: {
+          id: 1,
+          customerName: "株式会社ABC",
+        },
+      };
+
+      mockPrismaService.visit.create.mockResolvedValue(mockCreatedVisit);
+
+      const result = await visitsService.create(
+        1,
+        {
+          customer_id: 1,
+          visit_time: "10:00",
+          visit_purpose: "定期訪問",
+          visit_content: "新製品の提案を行った。",
+          result: "次回見積提出予定",
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.visit_id).toBe(1);
+      expect(result.data.visit_time).toBe("10:00");
+    });
+
+    // VST-002: 異常系 - 顧客ID未指定で422エラー（バリデーションはDTOで行うため省略）
+
+    // VST-003: 異常系 - 訪問内容未指定で422エラー（バリデーションはDTOで行うため省略）
+
+    // VST-004: 異常系 - 存在しない顧客IDで422エラー
+    it("VST-004: 存在しない顧客IDで422エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      mockPrismaService.customer.findUnique.mockResolvedValue(null);
+
+      await expect(
+        visitsService.create(
+          1,
+          {
+            customer_id: 999,
+            visit_content: "訪問内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    // VST-005: 異常系 - 提出済み日報への追加で403エラー
+    it("VST-005: 提出済み日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "submitted",
+      });
+
+      await expect(
+        visitsService.create(
+          1,
+          {
+            customer_id: 1,
+            visit_content: "訪問内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // VST-006: 異常系 - 他人の日報への追加で403エラー
+    it("VST-006: 他人の日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(
+        visitsService.create(
+          1,
+          {
+            customer_id: 1,
+            visit_content: "訪問内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // VST-007: 正常系 - 任意項目なしで登録できること
+    it("VST-007: 任意項目なしで登録できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      mockPrismaService.customer.findUnique.mockResolvedValue({ id: 1 });
+
+      const mockCreatedVisit = {
+        id: 1,
+        visitTime: null,
+        visitPurpose: null,
+        visitContent: "訪問内容",
+        result: null,
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        customer: {
+          id: 1,
+          customerName: "株式会社ABC",
+        },
+      };
+
+      mockPrismaService.visit.create.mockResolvedValue(mockCreatedVisit);
+
+      const result = await visitsService.create(
+        1,
+        {
+          customer_id: 1,
+          visit_content: "訪問内容",
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.visit_time).toBeNull();
+      expect(result.data.visit_purpose).toBeNull();
+      expect(result.data.result).toBeNull();
+    });
+  });
+
+  describe("update", () => {
+    // VST-010: 正常系 - 訪問記録を更新できること
+    it("VST-010: 訪問記録を更新できる", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      mockPrismaService.customer.findUnique.mockResolvedValue({ id: 2 });
+
+      const mockUpdatedVisit = {
+        id: 1,
+        visitTime: new Date("1970-01-01T14:00:00Z"),
+        visitPurpose: "緊急訪問",
+        visitContent: "クレーム対応を行った。",
+        result: "解決済み",
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T15:00:00Z"),
+        customer: {
+          id: 2,
+          customerName: "株式会社XYZ",
+        },
+      };
+
+      mockPrismaService.visit.update.mockResolvedValue(mockUpdatedVisit);
+
+      const result = await visitsService.update(
+        1,
+        {
+          customer_id: 2,
+          visit_time: "14:00",
+          visit_purpose: "緊急訪問",
+          visit_content: "クレーム対応を行った。",
+          result: "解決済み",
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.visit_time).toBe("14:00");
+    });
+
+    // VST-011: 異常系 - 提出済み日報の訪問記録更新で403エラー
+    it("VST-011: 提出済み日報の訪問記録更新で403エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(
+        visitsService.update(
+          1,
+          {
+            visit_content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // VST-012: 異常系 - 他人の訪問記録更新で403エラー
+    it("VST-012: 他人の訪問記録更新で403エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(
+        visitsService.update(
+          1,
+          {
+            visit_content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない訪問記録の更新で404エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue(null);
+
+      await expect(
+        visitsService.update(
+          999,
+          {
+            visit_content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("remove", () => {
+    // VST-013: 正常系 - 訪問記録を削除できること
+    it("VST-013: 訪問記録を削除できる", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      mockPrismaService.visit.delete.mockResolvedValue({ id: 1 });
+
+      const result = await visitsService.remove(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        message: "訪問記録を削除しました",
+      });
+    });
+
+    it("提出済み日報の訪問記録削除で403エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(visitsService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("他人の訪問記録削除で403エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(visitsService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない訪問記録の削除で404エラー", async () => {
+      mockPrismaService.visit.findUnique.mockResolvedValue(null);
+
+      await expect(visitsService.remove(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("admin access", () => {
+    it("adminは他人の日報の訪問記録一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1, // 他人のID
+        status: "draft",
+      });
+
+      mockPrismaService.visit.findMany.mockResolvedValue([]);
+
+      const result = await visitsService.findAll(1, mockAdminUser);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("adminは他人の日報に訪問記録を追加できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      mockPrismaService.customer.findUnique.mockResolvedValue({ id: 1 });
+
+      const mockCreatedVisit = {
+        id: 1,
+        visitTime: null,
+        visitPurpose: null,
+        visitContent: "訪問内容",
+        result: null,
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        customer: {
+          id: 1,
+          customerName: "株式会社ABC",
+        },
+      };
+
+      mockPrismaService.visit.create.mockResolvedValue(mockCreatedVisit);
+
+      const result = await visitsService.create(
+        1,
+        {
+          customer_id: 1,
+          visit_content: "訪問内容",
+        },
+        mockAdminUser
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/visits/visits.service.ts
+++ b/src/visits/visits.service.ts
@@ -1,0 +1,353 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import type {
+  CreateVisitDto,
+  UpdateVisitDto,
+  VisitListResponseDto,
+  VisitDetailResponseDto,
+  VisitDeleteResponseDto,
+  VisitDto,
+} from "./dto";
+
+@Injectable()
+export class VisitsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 時刻文字列(HH:mm)をDateオブジェクトに変換
+   */
+  private parseTime(timeStr: string): Date {
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    const date = new Date(Date.UTC(1970, 0, 1, hours, minutes, 0));
+    return date;
+  }
+
+  /**
+   * DateオブジェクトをHH:mm形式の文字列に変換
+   */
+  private formatTime(date: Date): string {
+    const hours = date.getUTCHours().toString().padStart(2, "0");
+    const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+    return `${hours}:${minutes}`;
+  }
+
+  /**
+   * 訪問データをDTOに変換
+   */
+  private toVisitDto(visit: {
+    id: number;
+    visitTime: Date | null;
+    visitPurpose: string | null;
+    visitContent: string;
+    result: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    customer: {
+      id: number;
+      customerName: string;
+    };
+  }): VisitDto {
+    return {
+      visit_id: visit.id,
+      customer: {
+        customer_id: visit.customer.id,
+        customer_name: visit.customer.customerName,
+      },
+      visit_time: visit.visitTime ? this.formatTime(visit.visitTime) : null,
+      visit_purpose: visit.visitPurpose,
+      visit_content: visit.visitContent,
+      result: visit.result,
+      created_at: visit.createdAt.toISOString(),
+      updated_at: visit.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 日報の所有権と編集可能状態をチェック
+   */
+  private async checkReportAccess(
+    reportId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{ salespersonId: number; status: string }> {
+    const report = await this.prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: {
+        salespersonId: true,
+        status: true,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "日報が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && report.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この日報にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && report.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return report;
+  }
+
+  /**
+   * 訪問記録の所有権チェック
+   */
+  private async checkVisitAccess(
+    visitId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{
+    id: number;
+    reportId: number;
+    report: { salespersonId: number; status: string };
+  }> {
+    const visit = await this.prisma.visit.findUnique({
+      where: { id: visitId },
+      select: {
+        id: true,
+        reportId: true,
+        dailyReport: {
+          select: {
+            salespersonId: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    if (!visit) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "訪問記録が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && visit.dailyReport.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この訪問記録にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && visit.dailyReport.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return {
+      id: visit.id,
+      reportId: visit.reportId,
+      report: visit.dailyReport,
+    };
+  }
+
+  /**
+   * 顧客の存在確認
+   */
+  private async checkCustomerExists(customerId: number): Promise<void> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+      select: { id: true },
+    });
+
+    if (!customer) {
+      throw new UnprocessableEntityException({
+        code: "VALIDATION_ERROR",
+        message: "指定された顧客が存在しません",
+      });
+    }
+  }
+
+  /**
+   * 訪問記録一覧を取得する
+   */
+  async findAll(reportId: number, user: AuthenticatedUser): Promise<VisitListResponseDto> {
+    // 日報のアクセス権チェック
+    await this.checkReportAccess(reportId, user);
+
+    // 訪問記録を取得
+    const visits = await this.prisma.visit.findMany({
+      where: { reportId },
+      select: {
+        id: true,
+        visitTime: true,
+        visitPurpose: true,
+        visitContent: true,
+        result: true,
+        createdAt: true,
+        updatedAt: true,
+        customer: {
+          select: {
+            id: true,
+            customerName: true,
+          },
+        },
+      },
+      orderBy: { id: "asc" },
+    });
+
+    return {
+      success: true,
+      data: visits.map((v) => this.toVisitDto(v)),
+    };
+  }
+
+  /**
+   * 訪問記録を作成する
+   */
+  async create(
+    reportId: number,
+    dto: CreateVisitDto,
+    user: AuthenticatedUser
+  ): Promise<VisitDetailResponseDto> {
+    // 日報のアクセス権と編集可能状態チェック
+    await this.checkReportAccess(reportId, user, true);
+
+    // 顧客の存在確認
+    await this.checkCustomerExists(dto.customer_id);
+
+    // 訪問記録を作成
+    const visit = await this.prisma.visit.create({
+      data: {
+        reportId,
+        customerId: dto.customer_id,
+        visitTime: dto.visit_time ? this.parseTime(dto.visit_time) : null,
+        visitPurpose: dto.visit_purpose ?? null,
+        visitContent: dto.visit_content,
+        result: dto.result ?? null,
+      },
+      select: {
+        id: true,
+        visitTime: true,
+        visitPurpose: true,
+        visitContent: true,
+        result: true,
+        createdAt: true,
+        updatedAt: true,
+        customer: {
+          select: {
+            id: true,
+            customerName: true,
+          },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toVisitDto(visit),
+    };
+  }
+
+  /**
+   * 訪問記録を更新する
+   */
+  async update(
+    visitId: number,
+    dto: UpdateVisitDto,
+    user: AuthenticatedUser
+  ): Promise<VisitDetailResponseDto> {
+    // 訪問記録のアクセス権と編集可能状態チェック
+    await this.checkVisitAccess(visitId, user, true);
+
+    // 顧客IDが指定されている場合は存在確認
+    if (dto.customer_id !== undefined) {
+      await this.checkCustomerExists(dto.customer_id);
+    }
+
+    // 更新データの構築
+    const updateData: {
+      customerId?: number;
+      visitTime?: Date | null;
+      visitPurpose?: string | null;
+      visitContent?: string;
+      result?: string | null;
+    } = {};
+
+    if (dto.customer_id !== undefined) {
+      updateData.customerId = dto.customer_id;
+    }
+    if (dto.visit_time !== undefined) {
+      updateData.visitTime = dto.visit_time ? this.parseTime(dto.visit_time) : null;
+    }
+    if (dto.visit_purpose !== undefined) {
+      updateData.visitPurpose = dto.visit_purpose;
+    }
+    if (dto.visit_content !== undefined) {
+      updateData.visitContent = dto.visit_content;
+    }
+    if (dto.result !== undefined) {
+      updateData.result = dto.result;
+    }
+
+    // 訪問記録を更新
+    const visit = await this.prisma.visit.update({
+      where: { id: visitId },
+      data: updateData,
+      select: {
+        id: true,
+        visitTime: true,
+        visitPurpose: true,
+        visitContent: true,
+        result: true,
+        createdAt: true,
+        updatedAt: true,
+        customer: {
+          select: {
+            id: true,
+            customerName: true,
+          },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toVisitDto(visit),
+    };
+  }
+
+  /**
+   * 訪問記録を削除する
+   */
+  async remove(visitId: number, user: AuthenticatedUser): Promise<VisitDeleteResponseDto> {
+    // 訪問記録のアクセス権と編集可能状態チェック
+    await this.checkVisitAccess(visitId, user, true);
+
+    // 訪問記録を削除
+    await this.prisma.visit.delete({
+      where: { id: visitId },
+    });
+
+    return {
+      success: true,
+      message: "訪問記録を削除しました",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- 訪問記録のCRUD APIを実装
- GET /reports/{id}/visits - 訪問記録一覧取得
- POST /reports/{id}/visits - 訪問記録登録
- PUT /visits/{id} - 訪問記録更新
- DELETE /visits/{id} - 訪問記録削除

## Changes
- `src/visits/` - 新規VisitsModuleを作成
  - `dto/` - CreateVisitDto, UpdateVisitDto, VisitResponseDto
  - `visits.service.ts` - CRUD操作とアクセス制御ロジック
  - `visits.controller.ts` - REST APIエンドポイント
- `src/app.module.ts` - VisitsModuleを登録

## Key Features
- 権限チェック: 自分の日報のみ編集可（adminは全員可）
- 提出済み日報の編集禁止
- 顧客存在チェック（422エラー）
- HH:mm形式の時刻バリデーション

## Test plan
- [x] 訪問記録一覧取得 (GET /reports/{id}/visits)
- [x] 訪問記録登録 (POST /reports/{id}/visits) - VST-001, VST-004~007
- [x] 訪問記録更新 (PUT /visits/{id}) - VST-010~012
- [x] 訪問記録削除 (DELETE /visits/{id}) - VST-013
- [x] 権限エラー（他人の日報、提出済み日報）
- [x] テスト全件パス (149 tests)
- [x] Lint・TypeCheckパス

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)