### PR TITLE
feat(comments): コメントAPI (Issue #18)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { SalespersonsModule } from "./salespersons";
 import { CustomersModule } from "./customers";
 import { ReportsModule } from "./reports";
 import { VisitsModule } from "./visits";
+import { ProblemsModule } from "./problems";
 import { GlobalExceptionFilter } from "./common/filters";
 import { TransformResponseInterceptor } from "./common/interceptors";
 
@@ -29,6 +30,8 @@ import { TransformResponseInterceptor } from "./common/interceptors";
     ReportsModule,
     // 訪問記録モジュール
     VisitsModule,
+    // 課題・相談モジュール
+    ProblemsModule,
   ],
   controllers: [],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ReportsModule } from "./reports";
 import { VisitsModule } from "./visits";
 import { ProblemsModule } from "./problems";
 import { PlansModule } from "./plans";
+import { CommentsModule } from "./comments";
 import { GlobalExceptionFilter } from "./common/filters";
 import { TransformResponseInterceptor } from "./common/interceptors";
 
@@ -35,6 +36,8 @@ import { TransformResponseInterceptor } from "./common/interceptors";
     ProblemsModule,
     // 計画モジュール
     PlansModule,
+    // コメントモジュール
+    CommentsModule,
   ],
   controllers: [],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { CustomersModule } from "./customers";
 import { ReportsModule } from "./reports";
 import { VisitsModule } from "./visits";
 import { ProblemsModule } from "./problems";
+import { PlansModule } from "./plans";
 import { GlobalExceptionFilter } from "./common/filters";
 import { TransformResponseInterceptor } from "./common/interceptors";
 
@@ -32,6 +33,8 @@ import { TransformResponseInterceptor } from "./common/interceptors";
     VisitsModule,
     // 課題・相談モジュール
     ProblemsModule,
+    // 計画モジュール
+    PlansModule,
   ],
   controllers: [],
   providers: [

--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommentsController } from "./comments.controller";
+import type { CommentsService } from "./comments.service";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("CommentsController", () => {
+  let commentsController: CommentsController;
+
+  const mockManagerUser: AuthenticatedUser = {
+    id: 10,
+    email: "suzuki@example.com",
+    name: "鈴木 部長",
+    role: "manager" as const,
+  };
+
+  const mockCommentsService = {
+    findByProblem: vi.fn(),
+    createForProblem: vi.fn(),
+    findByPlan: vi.fn(),
+    createForPlan: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    commentsController = new CommentsController(mockCommentsService as unknown as CommentsService);
+  });
+
+  describe("findByProblem", () => {
+    it("CMT-010: Problemのコメント一覧を取得できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: [
+          {
+            comment_id: 1,
+            commenter: {
+              salesperson_id: 10,
+              name: "鈴木 部長",
+            },
+            content: "この件について対応策を考えましょう",
+            created_at: "2026-02-15T10:30:00.000Z",
+          },
+        ],
+      };
+
+      mockCommentsService.findByProblem.mockResolvedValue(mockResponse);
+
+      const result = await commentsController.findByProblem(1, { user: mockManagerUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockCommentsService.findByProblem).toHaveBeenCalledWith(1, mockManagerUser);
+    });
+  });
+
+  describe("createForProblem", () => {
+    it("CMT-001: Problemにコメントを投稿できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          comment_id: 1,
+          commenter: {
+            salesperson_id: 10,
+            name: "鈴木 部長",
+          },
+          content: "この件について対応策を考えましょう",
+          created_at: "2026-02-15T10:30:00.000Z",
+        },
+      };
+
+      mockCommentsService.createForProblem.mockResolvedValue(mockResponse);
+
+      const dto = { content: "この件について対応策を考えましょう" };
+
+      const result = await commentsController.createForProblem(1, dto, { user: mockManagerUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockCommentsService.createForProblem).toHaveBeenCalledWith(1, dto, mockManagerUser);
+    });
+  });
+
+  describe("findByPlan", () => {
+    it("CMT-011: Planのコメント一覧を取得できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: [
+          {
+            comment_id: 2,
+            commenter: {
+              salesperson_id: 10,
+              name: "鈴木 部長",
+            },
+            content: "計画について確認させてください",
+            created_at: "2026-02-15T11:00:00.000Z",
+          },
+        ],
+      };
+
+      mockCommentsService.findByPlan.mockResolvedValue(mockResponse);
+
+      const result = await commentsController.findByPlan(1, { user: mockManagerUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockCommentsService.findByPlan).toHaveBeenCalledWith(1, mockManagerUser);
+    });
+  });
+
+  describe("createForPlan", () => {
+    it("CMT-002: Planにコメントを投稿できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          comment_id: 2,
+          commenter: {
+            salesperson_id: 10,
+            name: "鈴木 部長",
+          },
+          content: "計画について確認させてください",
+          created_at: "2026-02-15T11:00:00.000Z",
+        },
+      };
+
+      mockCommentsService.createForPlan.mockResolvedValue(mockResponse);
+
+      const dto = { content: "計画について確認させてください" };
+
+      const result = await commentsController.createForPlan(1, dto, { user: mockManagerUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockCommentsService.createForPlan).toHaveBeenCalledWith(1, dto, mockManagerUser);
+    });
+  });
+
+  describe("remove", () => {
+    it("CMT-020: コメントを削除できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          message: "コメントを削除しました",
+        },
+      };
+
+      mockCommentsService.remove.mockResolvedValue(mockResponse);
+
+      const result = await commentsController.remove(1, { user: mockManagerUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockCommentsService.remove).toHaveBeenCalledWith(1, mockManagerUser);
+    });
+  });
+});

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,231 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { CommentsService } from "./comments.service";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS validation requires runtime class reference
+import {
+  CreateCommentDto,
+  CommentListResponseDto,
+  CommentDetailResponseDto,
+  CommentDeleteResponseDto,
+} from "./dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+@ApiTags("コメント")
+@Controller()
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  /**
+   * Problemコメント一覧取得
+   */
+  @Get("problems/:id/comments")
+  @ApiOperation({
+    summary: "Problemコメント取得",
+    description: "指定したProblemのコメント一覧を取得する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Problem ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "取得成功",
+    type: CommentListResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報へのアクセス）",
+  })
+  @ApiNotFoundResponse({
+    description: "課題・相談が見つからない",
+  })
+  async findByProblem(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<CommentListResponseDto> {
+    return this.commentsService.findByProblem(id, req.user);
+  }
+
+  /**
+   * Problemコメント投稿
+   */
+  @Post("problems/:id/comments")
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Problemコメント投稿",
+    description:
+      "Problemにコメントを投稿する。上長は部下の日報にのみコメント可能。adminは全ての日報にコメント可能。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Problem ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 201,
+    description: "投稿成功",
+    type: CommentDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（営業担当者による投稿、または担当外の日報への投稿）",
+  })
+  @ApiNotFoundResponse({
+    description: "課題・相談が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（内容未入力等）",
+  })
+  async createForProblem(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: CreateCommentDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<CommentDetailResponseDto> {
+    return this.commentsService.createForProblem(id, dto, req.user);
+  }
+
+  /**
+   * Planコメント一覧取得
+   */
+  @Get("plans/:id/comments")
+  @ApiOperation({
+    summary: "Planコメント取得",
+    description: "指定したPlanのコメント一覧を取得する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Plan ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "取得成功",
+    type: CommentListResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報へのアクセス）",
+  })
+  @ApiNotFoundResponse({
+    description: "計画が見つからない",
+  })
+  async findByPlan(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<CommentListResponseDto> {
+    return this.commentsService.findByPlan(id, req.user);
+  }
+
+  /**
+   * Planコメント投稿
+   */
+  @Post("plans/:id/comments")
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Planコメント投稿",
+    description:
+      "Planにコメントを投稿する。上長は部下の日報にのみコメント可能。adminは全ての日報にコメント可能。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Plan ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 201,
+    description: "投稿成功",
+    type: CommentDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（営業担当者による投稿、または担当外の日報への投稿）",
+  })
+  @ApiNotFoundResponse({
+    description: "計画が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（内容未入力等）",
+  })
+  async createForPlan(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: CreateCommentDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<CommentDetailResponseDto> {
+    return this.commentsService.createForPlan(id, dto, req.user);
+  }
+
+  /**
+   * コメント削除
+   */
+  @Delete("comments/:id")
+  @ApiOperation({
+    summary: "コメント削除",
+    description:
+      "コメントを削除する。上長は自分のコメントのみ削除可能。adminは全てのコメントを削除可能。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Comment ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "削除成功",
+    type: CommentDeleteResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（営業担当者による削除、または他人のコメントの削除）",
+  })
+  @ApiNotFoundResponse({
+    description: "コメントが見つからない",
+  })
+  async remove(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<CommentDeleteResponseDto> {
+    return this.commentsService.remove(id, req.user);
+  }
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { CommentsController } from "./comments.controller";
+import { CommentsService } from "./comments.service";
+
+@Module({
+  controllers: [CommentsController],
+  providers: [CommentsService],
+  exports: [CommentsService],
+})
+export class CommentsModule {}

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,449 @@
+import { NotFoundException, ForbiddenException } from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommentsService } from "./comments.service";
+import type { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("CommentsService", () => {
+  let commentsService: CommentsService;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockManagerUser: AuthenticatedUser = {
+    id: 10,
+    email: "suzuki@example.com",
+    name: "鈴木 部長",
+    role: "manager" as const,
+  };
+
+  const mockAdminUser: AuthenticatedUser = {
+    id: 99,
+    email: "admin@example.com",
+    name: "Admin",
+    role: "admin" as const,
+  };
+
+  const mockPrismaService = {
+    problem: {
+      findUnique: vi.fn(),
+    },
+    plan: {
+      findUnique: vi.fn(),
+    },
+    comment: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    salesperson: {
+      findFirst: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    commentsService = new CommentsService(mockPrismaService as unknown as PrismaService);
+  });
+
+  describe("findByProblem", () => {
+    // CMT-010: Problemコメント取得
+    it("CMT-010: Problemのコメント一覧を取得できる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      const mockComments = [
+        {
+          id: 1,
+          content: "この件について対応策を考えましょう",
+          createdAt: new Date("2026-02-15T10:30:00Z"),
+          commenter: {
+            id: 10,
+            name: "鈴木 部長",
+          },
+        },
+      ];
+
+      mockPrismaService.comment.findMany.mockResolvedValue(mockComments);
+
+      const result = await commentsService.findByProblem(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [
+          {
+            comment_id: 1,
+            commenter: {
+              salesperson_id: 10,
+              name: "鈴木 部長",
+            },
+            content: "この件について対応策を考えましょう",
+            created_at: "2026-02-15T10:30:00.000Z",
+          },
+        ],
+      });
+    });
+
+    // CMT-012: コメントなしの取得
+    it("CMT-012: コメントがない場合は空配列を返す", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      mockPrismaService.comment.findMany.mockResolvedValue([]);
+
+      const result = await commentsService.findByProblem(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [],
+      });
+    });
+
+    it("存在しないProblemで404エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue(null);
+
+      await expect(commentsService.findByProblem(999, mockSalesUser)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("営業は自分の日報のコメントのみ閲覧可能", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 999, // 他人のID
+        },
+      });
+
+      await expect(commentsService.findByProblem(1, mockSalesUser)).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("マネージャーは部下の日報のコメントを閲覧可能", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1, // 部下のID
+        },
+      });
+
+      mockPrismaService.salesperson.findFirst.mockResolvedValue({
+        id: 1,
+        managerId: 10, // マネージャーのID
+      });
+
+      mockPrismaService.comment.findMany.mockResolvedValue([]);
+
+      const result = await commentsService.findByProblem(1, mockManagerUser);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("createForProblem", () => {
+    // CMT-001: Problemへのコメント（上長）
+    it("CMT-001: マネージャーは部下の日報のProblemにコメントできる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      // 部下かどうかの確認
+      mockPrismaService.salesperson.findFirst.mockResolvedValue({
+        id: 1,
+        managerId: 10,
+      });
+
+      const mockCreatedComment = {
+        id: 1,
+        content: "この件について対応策を考えましょう",
+        createdAt: new Date("2026-02-15T10:30:00Z"),
+        commenter: {
+          id: 10,
+          name: "鈴木 部長",
+        },
+      };
+
+      mockPrismaService.comment.create.mockResolvedValue(mockCreatedComment);
+
+      const result = await commentsService.createForProblem(
+        1,
+        { content: "この件について対応策を考えましょう" },
+        mockManagerUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.comment_id).toBe(1);
+      expect(result.data.commenter.salesperson_id).toBe(10);
+    });
+
+    // CMT-004: 営業によるコメント（403エラー）
+    it("CMT-004: 営業担当者はコメントを投稿できない", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      await expect(
+        commentsService.createForProblem(1, { content: "コメント" }, mockSalesUser)
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // CMT-006: 担当外へのコメント（403エラー）
+    it("CMT-006: マネージャーは担当外の日報にコメントできない", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 999, // 担当外の営業担当者
+        },
+      });
+
+      // 部下ではない
+      mockPrismaService.salesperson.findFirst.mockResolvedValue(null);
+
+      await expect(
+        commentsService.createForProblem(1, { content: "コメント" }, mockManagerUser)
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しないProblemへのコメントで404エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue(null);
+
+      await expect(
+        commentsService.createForProblem(999, { content: "コメント" }, mockManagerUser)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    // CMT-005: 複数コメント投稿
+    it("CMT-005: 同一Problemに複数コメントを投稿できる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      mockPrismaService.salesperson.findFirst.mockResolvedValue({
+        id: 1,
+        managerId: 10,
+      });
+
+      // 3つのコメントを投稿
+      for (let i = 1; i <= 3; i++) {
+        const mockComment = {
+          id: i,
+          content: `コメント${i}`,
+          createdAt: new Date(),
+          commenter: { id: 10, name: "鈴木 部長" },
+        };
+        mockPrismaService.comment.create.mockResolvedValueOnce(mockComment);
+
+        const result = await commentsService.createForProblem(
+          1,
+          { content: `コメント${i}` },
+          mockManagerUser
+        );
+
+        expect(result.success).toBe(true);
+      }
+
+      expect(mockPrismaService.comment.create).toHaveBeenCalledTimes(3);
+    });
+
+    it("adminは全ての日報にコメントできる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      const mockCreatedComment = {
+        id: 1,
+        content: "管理者からのコメント",
+        createdAt: new Date("2026-02-15T10:30:00Z"),
+        commenter: {
+          id: 99,
+          name: "Admin",
+        },
+      };
+
+      mockPrismaService.comment.create.mockResolvedValue(mockCreatedComment);
+
+      const result = await commentsService.createForProblem(
+        1,
+        { content: "管理者からのコメント" },
+        mockAdminUser
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("findByPlan", () => {
+    // CMT-011: Planコメント取得
+    it("CMT-011: Planのコメント一覧を取得できる", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      const mockComments = [
+        {
+          id: 2,
+          content: "この計画について確認させてください",
+          createdAt: new Date("2026-02-15T11:00:00Z"),
+          commenter: {
+            id: 10,
+            name: "鈴木 部長",
+          },
+        },
+      ];
+
+      mockPrismaService.comment.findMany.mockResolvedValue(mockComments);
+
+      const result = await commentsService.findByPlan(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [
+          {
+            comment_id: 2,
+            commenter: {
+              salesperson_id: 10,
+              name: "鈴木 部長",
+            },
+            content: "この計画について確認させてください",
+            created_at: "2026-02-15T11:00:00.000Z",
+          },
+        ],
+      });
+    });
+
+    it("存在しないPlanで404エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(commentsService.findByPlan(999, mockSalesUser)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe("createForPlan", () => {
+    // CMT-002: Planへのコメント（上長）
+    it("CMT-002: マネージャーは部下の日報のPlanにコメントできる", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      mockPrismaService.salesperson.findFirst.mockResolvedValue({
+        id: 1,
+        managerId: 10,
+      });
+
+      const mockCreatedComment = {
+        id: 2,
+        content: "計画について確認させてください",
+        createdAt: new Date("2026-02-15T11:00:00Z"),
+        commenter: {
+          id: 10,
+          name: "鈴木 部長",
+        },
+      };
+
+      mockPrismaService.comment.create.mockResolvedValue(mockCreatedComment);
+
+      const result = await commentsService.createForPlan(
+        1,
+        { content: "計画について確認させてください" },
+        mockManagerUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.comment_id).toBe(2);
+    });
+
+    it("営業担当者はPlanにコメントできない", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        dailyReport: {
+          salespersonId: 1,
+        },
+      });
+
+      await expect(
+        commentsService.createForPlan(1, { content: "コメント" }, mockSalesUser)
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("remove", () => {
+    // CMT-020: 自分のコメント削除
+    it("CMT-020: マネージャーは自分のコメントを削除できる", async () => {
+      mockPrismaService.comment.findUnique.mockResolvedValue({
+        id: 1,
+        commenterId: 10, // マネージャーのID
+      });
+
+      mockPrismaService.comment.delete.mockResolvedValue({ id: 1 });
+
+      const result = await commentsService.remove(1, mockManagerUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: {
+          message: "コメントを削除しました",
+        },
+      });
+    });
+
+    // CMT-021: 他人のコメント削除（403エラー）
+    it("CMT-021: マネージャーは他人のコメントを削除できない", async () => {
+      mockPrismaService.comment.findUnique.mockResolvedValue({
+        id: 1,
+        commenterId: 99, // 別のユーザーのID
+      });
+
+      await expect(commentsService.remove(1, mockManagerUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("営業担当者はコメントを削除できない", async () => {
+      mockPrismaService.comment.findUnique.mockResolvedValue({
+        id: 1,
+        commenterId: 1,
+      });
+
+      await expect(commentsService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("adminは全てのコメントを削除できる", async () => {
+      mockPrismaService.comment.findUnique.mockResolvedValue({
+        id: 1,
+        commenterId: 10, // 他人のコメント
+      });
+
+      mockPrismaService.comment.delete.mockResolvedValue({ id: 1 });
+
+      const result = await commentsService.remove(1, mockAdminUser);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("存在しないコメントの削除で404エラー", async () => {
+      mockPrismaService.comment.findUnique.mockResolvedValue(null);
+
+      await expect(commentsService.remove(999, mockManagerUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,394 @@
+import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
+import type { CommentTargetType } from "@prisma/client";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import type {
+  CreateCommentDto,
+  CommentListResponseDto,
+  CommentDetailResponseDto,
+  CommentDeleteResponseDto,
+  CommentDto,
+} from "./dto";
+
+@Injectable()
+export class CommentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * CommentデータをDTOに変換
+   */
+  private toCommentDto(comment: {
+    id: number;
+    content: string;
+    createdAt: Date;
+    commenter: { id: number; name: string };
+  }): CommentDto {
+    return {
+      comment_id: comment.id,
+      commenter: {
+        salesperson_id: comment.commenter.id,
+        name: comment.commenter.name,
+      },
+      content: comment.content,
+      created_at: comment.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * 上長がコメント可能かどうかをチェック
+   * managerは部下の日報にのみコメント可能
+   * adminは全ての日報にコメント可能
+   */
+  private async checkCommentPermission(
+    reportSalespersonId: number,
+    user: AuthenticatedUser
+  ): Promise<void> {
+    // salesはコメント投稿不可
+    if (user.role === "sales") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "営業担当者はコメントを投稿できません",
+      });
+    }
+
+    // adminは全ての日報にコメント可能
+    if (user.role === "admin") {
+      return;
+    }
+
+    // managerは部下の日報にのみコメント可能
+    if (user.role === "manager") {
+      // 自分の部下かどうかを確認
+      const subordinate = await this.prisma.salesperson.findFirst({
+        where: {
+          id: reportSalespersonId,
+          managerId: user.id,
+        },
+      });
+
+      if (!subordinate) {
+        throw new ForbiddenException({
+          code: "FORBIDDEN",
+          message: "担当外の日報にはコメントできません",
+        });
+      }
+    }
+  }
+
+  /**
+   * 日報の閲覧権限チェック
+   */
+  private async checkReportViewAccess(
+    reportSalespersonId: number,
+    user: AuthenticatedUser
+  ): Promise<void> {
+    // adminは全ての日報を閲覧可能
+    if (user.role === "admin") {
+      return;
+    }
+
+    // salesは自分の日報のみ閲覧可能
+    if (user.role === "sales") {
+      if (reportSalespersonId !== user.id) {
+        throw new ForbiddenException({
+          code: "FORBIDDEN",
+          message: "この日報にアクセスする権限がありません",
+        });
+      }
+      return;
+    }
+
+    // managerは自分の日報と部下の日報を閲覧可能
+    if (user.role === "manager") {
+      if (reportSalespersonId === user.id) {
+        return;
+      }
+
+      const subordinate = await this.prisma.salesperson.findFirst({
+        where: {
+          id: reportSalespersonId,
+          managerId: user.id,
+        },
+      });
+
+      if (!subordinate) {
+        throw new ForbiddenException({
+          code: "FORBIDDEN",
+          message: "この日報にアクセスする権限がありません",
+        });
+      }
+    }
+  }
+
+  /**
+   * Problemのコメント一覧を取得する
+   */
+  async findByProblem(problemId: number, user: AuthenticatedUser): Promise<CommentListResponseDto> {
+    // Problemの存在確認と日報情報取得
+    const problem = await this.prisma.problem.findUnique({
+      where: { id: problemId },
+      select: {
+        dailyReport: {
+          select: {
+            salespersonId: true,
+          },
+        },
+      },
+    });
+
+    if (!problem) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "課題・相談が見つかりません",
+      });
+    }
+
+    // 閲覧権限チェック
+    await this.checkReportViewAccess(problem.dailyReport.salespersonId, user);
+
+    // コメントを取得
+    const comments = await this.prisma.comment.findMany({
+      where: {
+        targetType: "problem" as CommentTargetType,
+        targetId: problemId,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        commenter: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return {
+      success: true,
+      data: comments.map((c) => this.toCommentDto(c)),
+    };
+  }
+
+  /**
+   * Problemにコメントを投稿する
+   */
+  async createForProblem(
+    problemId: number,
+    dto: CreateCommentDto,
+    user: AuthenticatedUser
+  ): Promise<CommentDetailResponseDto> {
+    // Problemの存在確認と日報情報取得
+    const problem = await this.prisma.problem.findUnique({
+      where: { id: problemId },
+      select: {
+        dailyReport: {
+          select: {
+            salespersonId: true,
+          },
+        },
+      },
+    });
+
+    if (!problem) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "課題・相談が見つかりません",
+      });
+    }
+
+    // コメント投稿権限チェック
+    await this.checkCommentPermission(problem.dailyReport.salespersonId, user);
+
+    // コメントを作成
+    const comment = await this.prisma.comment.create({
+      data: {
+        targetType: "problem" as CommentTargetType,
+        targetId: problemId,
+        problemId: problemId,
+        commenterId: user.id,
+        content: dto.content,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        commenter: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toCommentDto(comment),
+    };
+  }
+
+  /**
+   * Planのコメント一覧を取得する
+   */
+  async findByPlan(planId: number, user: AuthenticatedUser): Promise<CommentListResponseDto> {
+    // Planの存在確認と日報情報取得
+    const plan = await this.prisma.plan.findUnique({
+      where: { id: planId },
+      select: {
+        dailyReport: {
+          select: {
+            salespersonId: true,
+          },
+        },
+      },
+    });
+
+    if (!plan) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "計画が見つかりません",
+      });
+    }
+
+    // 閲覧権限チェック
+    await this.checkReportViewAccess(plan.dailyReport.salespersonId, user);
+
+    // コメントを取得
+    const comments = await this.prisma.comment.findMany({
+      where: {
+        targetType: "plan" as CommentTargetType,
+        targetId: planId,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        commenter: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return {
+      success: true,
+      data: comments.map((c) => this.toCommentDto(c)),
+    };
+  }
+
+  /**
+   * Planにコメントを投稿する
+   */
+  async createForPlan(
+    planId: number,
+    dto: CreateCommentDto,
+    user: AuthenticatedUser
+  ): Promise<CommentDetailResponseDto> {
+    // Planの存在確認と日報情報取得
+    const plan = await this.prisma.plan.findUnique({
+      where: { id: planId },
+      select: {
+        dailyReport: {
+          select: {
+            salespersonId: true,
+          },
+        },
+      },
+    });
+
+    if (!plan) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "計画が見つかりません",
+      });
+    }
+
+    // コメント投稿権限チェック
+    await this.checkCommentPermission(plan.dailyReport.salespersonId, user);
+
+    // コメントを作成
+    const comment = await this.prisma.comment.create({
+      data: {
+        targetType: "plan" as CommentTargetType,
+        targetId: planId,
+        planId: planId,
+        commenterId: user.id,
+        content: dto.content,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        commenter: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toCommentDto(comment),
+    };
+  }
+
+  /**
+   * コメントを削除する
+   * managerは自分のコメントのみ削除可能
+   * adminは全てのコメントを削除可能
+   */
+  async remove(commentId: number, user: AuthenticatedUser): Promise<CommentDeleteResponseDto> {
+    // コメントの存在確認
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: commentId },
+      select: {
+        id: true,
+        commenterId: true,
+      },
+    });
+
+    if (!comment) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "コメントが見つかりません",
+      });
+    }
+
+    // salesはコメント削除不可
+    if (user.role === "sales") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "営業担当者はコメントを削除できません",
+      });
+    }
+
+    // managerは自分のコメントのみ削除可能
+    if (user.role === "manager" && comment.commenterId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "他のユーザーのコメントは削除できません",
+      });
+    }
+
+    // コメントを削除
+    await this.prisma.comment.delete({
+      where: { id: commentId },
+    });
+
+    return {
+      success: true,
+      data: {
+        message: "コメントを削除しました",
+      },
+    };
+  }
+}

--- a/src/comments/dto/comment-response.dto.ts
+++ b/src/comments/dto/comment-response.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * コメント投稿者DTO
+ */
+export class CommenterDto {
+  @ApiProperty({ description: "営業担当者ID", example: 10 })
+  salesperson_id!: number;
+
+  @ApiProperty({ description: "名前", example: "鈴木 部長" })
+  name!: string;
+}
+
+/**
+ * CommentDTO
+ */
+export class CommentDto {
+  @ApiProperty({ description: "Comment ID", example: 1 })
+  comment_id!: number;
+
+  @ApiProperty({ description: "コメント投稿者", type: CommenterDto })
+  commenter!: CommenterDto;
+
+  @ApiProperty({ description: "コメント内容", example: "この件について、明日までに対応策を考えましょう" })
+  content!: string;
+
+  @ApiProperty({ description: "作成日時", example: "2026-02-15T10:30:00.000Z" })
+  created_at!: string;
+}
+
+/**
+ * Comment一覧レスポンスDTO
+ */
+export class CommentListResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Comment一覧", type: [CommentDto] })
+  data!: CommentDto[];
+}
+
+/**
+ * Comment詳細レスポンスDTO
+ */
+export class CommentDetailResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Comment", type: CommentDto })
+  data!: CommentDto;
+}
+
+/**
+ * Comment削除レスポンスDTO
+ */
+export class CommentDeleteResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({
+    description: "削除結果",
+    example: { message: "コメントを削除しました" },
+  })
+  data!: { message: string };
+}

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString } from "class-validator";
+
+/**
+ * Comment作成DTO
+ */
+export class CreateCommentDto {
+  @ApiProperty({
+    description: "コメント内容",
+    example: "この件について、明日までに対応策を考えましょう",
+  })
+  @IsString({ message: "内容は文字列で指定してください" })
+  @IsNotEmpty({ message: "内容は必須です" })
+  content!: string;
+}

--- a/src/comments/dto/index.ts
+++ b/src/comments/dto/index.ts
@@ -1,0 +1,2 @@
+export * from "./create-comment.dto";
+export * from "./comment-response.dto";

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -1,0 +1,3 @@
+export * from "./comments.module";
+export * from "./comments.service";
+export * from "./comments.controller";

--- a/src/plans/dto/create-plan.dto.ts
+++ b/src/plans/dto/create-plan.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString } from "class-validator";
+
+/**
+ * Plan作成DTO
+ */
+export class CreatePlanDto {
+  @ApiProperty({
+    description: "明日やること",
+    example: "A社に見積書を提出する",
+  })
+  @IsString({ message: "内容は文字列で指定してください" })
+  @IsNotEmpty({ message: "内容は必須です" })
+  content!: string;
+}

--- a/src/plans/dto/index.ts
+++ b/src/plans/dto/index.ts
@@ -1,0 +1,3 @@
+export * from "./create-plan.dto";
+export * from "./update-plan.dto";
+export * from "./plan-response.dto";

--- a/src/plans/dto/plan-response.dto.ts
+++ b/src/plans/dto/plan-response.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * PlanDTO
+ */
+export class PlanDto {
+  @ApiProperty({ description: "Plan ID", example: 1 })
+  plan_id!: number;
+
+  @ApiProperty({ description: "明日やること", example: "A社に見積書を提出する" })
+  content!: string;
+
+  @ApiProperty({ description: "コメント数", example: 2 })
+  comment_count!: number;
+
+  @ApiProperty({ description: "作成日時", example: "2026-02-15T09:00:00.000Z" })
+  created_at!: string;
+
+  @ApiProperty({ description: "更新日時", example: "2026-02-15T09:00:00.000Z" })
+  updated_at!: string;
+}
+
+/**
+ * Plan一覧レスポンスDTO
+ */
+export class PlanListResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Plan一覧", type: [PlanDto] })
+  data!: PlanDto[];
+}
+
+/**
+ * Plan詳細レスポンスDTO
+ */
+export class PlanDetailResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Plan", type: PlanDto })
+  data!: PlanDto;
+}
+
+/**
+ * Plan削除レスポンスDTO
+ */
+export class PlanDeleteResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "メッセージ", example: "計画を削除しました" })
+  message!: string;
+}

--- a/src/plans/dto/update-plan.dto.ts
+++ b/src/plans/dto/update-plan.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional, IsString } from "class-validator";
+
+/**
+ * Plan更新DTO
+ */
+export class UpdatePlanDto {
+  @ApiPropertyOptional({
+    description: "明日やること",
+    example: "A社に見積書を提出する",
+  })
+  @IsOptional()
+  @IsString({ message: "内容は文字列で指定してください" })
+  content?: string;
+}

--- a/src/plans/index.ts
+++ b/src/plans/index.ts
@@ -1,0 +1,3 @@
+export * from "./plans.module";
+export * from "./plans.service";
+export * from "./plans.controller";

--- a/src/plans/plans.controller.spec.ts
+++ b/src/plans/plans.controller.spec.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlansController } from "./plans.controller";
+import type { PlansService } from "./plans.service";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("PlansController", () => {
+  let plansController: PlansController;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockPlansService = {
+    findAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plansController = new PlansController(mockPlansService as unknown as PlansService);
+  });
+
+  describe("findAll", () => {
+    it("Plan一覧を取得できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: [
+          {
+            plan_id: 1,
+            content: "A社に見積書を提出する",
+            comment_count: 2,
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      };
+
+      mockPlansService.findAll.mockResolvedValue(mockResponse);
+
+      const result = await plansController.findAll(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockPlansService.findAll).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+
+  describe("create", () => {
+    it("PLN-001: Planを登録できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          plan_id: 1,
+          content: "A社に見積書を提出する",
+          comment_count: 0,
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T09:00:00.000Z",
+        },
+      };
+
+      mockPlansService.create.mockResolvedValue(mockResponse);
+
+      const dto = {
+        content: "A社に見積書を提出する",
+      };
+
+      const result = await plansController.create(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockPlansService.create).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("update", () => {
+    it("PLN-010: Planを更新できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          plan_id: 1,
+          content: "更新された計画内容",
+          comment_count: 1,
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T15:00:00.000Z",
+        },
+      };
+
+      mockPlansService.update.mockResolvedValue(mockResponse);
+
+      const dto = {
+        content: "更新された計画内容",
+      };
+
+      const result = await plansController.update(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockPlansService.update).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("remove", () => {
+    it("PLN-012: Planを削除できる", async () => {
+      const mockResponse = {
+        success: true,
+        message: "計画を削除しました",
+      };
+
+      mockPlansService.remove.mockResolvedValue(mockResponse);
+
+      const result = await plansController.remove(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockPlansService.remove).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+});

--- a/src/plans/plans.controller.ts
+++ b/src/plans/plans.controller.ts
@@ -1,0 +1,191 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  Request,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { PlansService } from "./plans.service";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS validation requires runtime class reference
+import {
+  CreatePlanDto,
+  UpdatePlanDto,
+  PlanListResponseDto,
+  PlanDetailResponseDto,
+  PlanDeleteResponseDto,
+} from "./dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+@ApiTags("計画")
+@Controller()
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class PlansController {
+  constructor(private readonly plansService: PlansService) {}
+
+  /**
+   * Plan一覧取得
+   */
+  @Get("reports/:reportId/plans")
+  @ApiOperation({
+    summary: "計画一覧取得",
+    description: "指定した日報の計画一覧を取得する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "取得成功",
+    type: PlanListResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報にアクセス）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  async findAll(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<PlanListResponseDto> {
+    return this.plansService.findAll(reportId, req.user);
+  }
+
+  /**
+   * Plan登録
+   */
+  @Post("reports/:reportId/plans")
+  @ApiOperation({
+    summary: "計画登録",
+    description: "指定した日報に計画を登録する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 201,
+    description: "登録成功",
+    type: PlanDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報への追加、または提出済み日報への追加）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（必須項目未入力等）",
+  })
+  async create(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Body() dto: CreatePlanDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<PlanDetailResponseDto> {
+    return this.plansService.create(reportId, dto, req.user);
+  }
+
+  /**
+   * Plan更新
+   */
+  @Put("plans/:id")
+  @ApiOperation({
+    summary: "計画更新",
+    description: "指定した計画を更新する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Plan ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "更新成功",
+    type: PlanDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の計画の更新、または提出済み日報の計画の更新）",
+  })
+  @ApiNotFoundResponse({
+    description: "計画が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー",
+  })
+  async update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: UpdatePlanDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<PlanDetailResponseDto> {
+    return this.plansService.update(id, dto, req.user);
+  }
+
+  /**
+   * Plan削除
+   */
+  @Delete("plans/:id")
+  @ApiOperation({
+    summary: "計画削除",
+    description: "指定した計画を削除する。関連するコメントも削除される。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Plan ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "削除成功",
+    type: PlanDeleteResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の計画の削除、または提出済み日報の計画の削除）",
+  })
+  @ApiNotFoundResponse({
+    description: "計画が見つからない",
+  })
+  async remove(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<PlanDeleteResponseDto> {
+    return this.plansService.remove(id, req.user);
+  }
+}

--- a/src/plans/plans.module.ts
+++ b/src/plans/plans.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { PlansController } from "./plans.controller";
+import { PlansService } from "./plans.service";
+
+@Module({
+  controllers: [PlansController],
+  providers: [PlansService],
+  exports: [PlansService],
+})
+export class PlansModule {}

--- a/src/plans/plans.service.spec.ts
+++ b/src/plans/plans.service.spec.ts
@@ -1,0 +1,349 @@
+import { NotFoundException, ForbiddenException } from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlansService } from "./plans.service";
+import type { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+describe("PlansService", () => {
+  let plansService: PlansService;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockAdminUser: AuthenticatedUser = {
+    id: 99,
+    email: "admin@example.com",
+    name: "Admin",
+    role: "admin" as const,
+  };
+
+  const mockPrismaService = {
+    dailyReport: {
+      findUnique: vi.fn(),
+    },
+    plan: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plansService = new PlansService(mockPrismaService as unknown as PrismaService);
+  });
+
+  describe("findAll", () => {
+    it("日報のPlan一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockPlans = [
+        {
+          id: 1,
+          content: "A社に見積書を提出する",
+          createdAt: new Date("2026-02-15T09:00:00Z"),
+          updatedAt: new Date("2026-02-15T09:00:00Z"),
+          _count: { comments: 2 },
+        },
+      ];
+
+      mockPrismaService.plan.findMany.mockResolvedValue(mockPlans);
+
+      const result = await plansService.findAll(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [
+          {
+            plan_id: 1,
+            content: "A社に見積書を提出する",
+            comment_count: 2,
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      });
+    });
+
+    it("存在しない日報IDで404エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue(null);
+
+      await expect(plansService.findAll(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it("他人の日報へのアクセスで403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(plansService.findAll(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("create", () => {
+    // PLN-001: 正常系 - Planを登録できること
+    it("PLN-001: Planを登録できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockCreatedPlan = {
+        id: 1,
+        content: "A社に見積書を提出する",
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        _count: { comments: 0 },
+      };
+
+      mockPrismaService.plan.create.mockResolvedValue(mockCreatedPlan);
+
+      const result = await plansService.create(
+        1,
+        {
+          content: "A社に見積書を提出する",
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.plan_id).toBe(1);
+      expect(result.data.content).toBe("A社に見積書を提出する");
+    });
+
+    // PLN-002: 異常系 - 提出済み日報への追加で403エラー
+    it("PLN-002: 提出済み日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "submitted",
+      });
+
+      await expect(
+        plansService.create(
+          1,
+          {
+            content: "計画内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // PLN-003: 異常系 - 他人の日報への追加で403エラー
+    it("PLN-003: 他人の日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(
+        plansService.create(
+          1,
+          {
+            content: "計画内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("update", () => {
+    // PLN-010: 正常系 - Planを更新できること
+    it("PLN-010: Planを更新できる", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      const mockUpdatedPlan = {
+        id: 1,
+        content: "更新された計画内容",
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T15:00:00Z"),
+        _count: { comments: 1 },
+      };
+
+      mockPrismaService.plan.update.mockResolvedValue(mockUpdatedPlan);
+
+      const result = await plansService.update(
+        1,
+        {
+          content: "更新された計画内容",
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.content).toBe("更新された計画内容");
+    });
+
+    // PLN-011: 異常系 - 提出済み日報のPlan更新で403エラー
+    it("PLN-011: 提出済み日報のPlan更新で403エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(
+        plansService.update(
+          1,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("他人のPlan更新で403エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(
+        plansService.update(
+          1,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しないPlanの更新で404エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(
+        plansService.update(
+          999,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("remove", () => {
+    // PLN-012: 正常系 - Planを削除できること
+    it("PLN-012: Planを削除できる", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      mockPrismaService.plan.delete.mockResolvedValue({ id: 1 });
+
+      const result = await plansService.remove(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        message: "計画を削除しました",
+      });
+    });
+
+    it("提出済み日報のPlan削除で403エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(plansService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("他人のPlan削除で403エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(plansService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しないPlanの削除で404エラー", async () => {
+      mockPrismaService.plan.findUnique.mockResolvedValue(null);
+
+      await expect(plansService.remove(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("admin access", () => {
+    it("adminは他人の日報のPlan一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1, // 他人のID
+        status: "draft",
+      });
+
+      mockPrismaService.plan.findMany.mockResolvedValue([]);
+
+      const result = await plansService.findAll(1, mockAdminUser);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("adminは他人の日報にPlanを追加できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockCreatedPlan = {
+        id: 1,
+        content: "計画内容",
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        _count: { comments: 0 },
+      };
+
+      mockPrismaService.plan.create.mockResolvedValue(mockCreatedPlan);
+
+      const result = await plansService.create(
+        1,
+        {
+          content: "計画内容",
+        },
+        mockAdminUser
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/plans/plans.service.ts
+++ b/src/plans/plans.service.ts
@@ -1,0 +1,255 @@
+import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import type {
+  CreatePlanDto,
+  UpdatePlanDto,
+  PlanListResponseDto,
+  PlanDetailResponseDto,
+  PlanDeleteResponseDto,
+  PlanDto,
+} from "./dto";
+
+@Injectable()
+export class PlansService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * PlanデータをDTOに変換
+   */
+  private toPlanDto(plan: {
+    id: number;
+    content: string;
+    createdAt: Date;
+    updatedAt: Date;
+    _count: { comments: number };
+  }): PlanDto {
+    return {
+      plan_id: plan.id,
+      content: plan.content,
+      comment_count: plan._count.comments,
+      created_at: plan.createdAt.toISOString(),
+      updated_at: plan.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 日報の所有権と編集可能状態をチェック
+   */
+  private async checkReportAccess(
+    reportId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{ salespersonId: number; status: string }> {
+    const report = await this.prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: {
+        salespersonId: true,
+        status: true,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "日報が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && report.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この日報にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && report.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return report;
+  }
+
+  /**
+   * Planの所有権チェック
+   */
+  private async checkPlanAccess(
+    planId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{
+    id: number;
+    reportId: number;
+    report: { salespersonId: number; status: string };
+  }> {
+    const plan = await this.prisma.plan.findUnique({
+      where: { id: planId },
+      select: {
+        id: true,
+        reportId: true,
+        dailyReport: {
+          select: {
+            salespersonId: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    if (!plan) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "計画が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && plan.dailyReport.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この計画にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && plan.dailyReport.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return {
+      id: plan.id,
+      reportId: plan.reportId,
+      report: plan.dailyReport,
+    };
+  }
+
+  /**
+   * Plan一覧を取得する
+   */
+  async findAll(reportId: number, user: AuthenticatedUser): Promise<PlanListResponseDto> {
+    // 日報のアクセス権チェック
+    await this.checkReportAccess(reportId, user);
+
+    // Planを取得
+    const plans = await this.prisma.plan.findMany({
+      where: { reportId },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+      orderBy: { id: "asc" },
+    });
+
+    return {
+      success: true,
+      data: plans.map((p) => this.toPlanDto(p)),
+    };
+  }
+
+  /**
+   * Planを作成する
+   */
+  async create(
+    reportId: number,
+    dto: CreatePlanDto,
+    user: AuthenticatedUser
+  ): Promise<PlanDetailResponseDto> {
+    // 日報のアクセス権と編集可能状態チェック
+    await this.checkReportAccess(reportId, user, true);
+
+    // Planを作成
+    const plan = await this.prisma.plan.create({
+      data: {
+        reportId,
+        content: dto.content,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toPlanDto(plan),
+    };
+  }
+
+  /**
+   * Planを更新する
+   */
+  async update(
+    planId: number,
+    dto: UpdatePlanDto,
+    user: AuthenticatedUser
+  ): Promise<PlanDetailResponseDto> {
+    // Planのアクセス権と編集可能状態チェック
+    await this.checkPlanAccess(planId, user, true);
+
+    // 更新データの構築
+    const updateData: {
+      content?: string;
+    } = {};
+
+    if (dto.content !== undefined) {
+      updateData.content = dto.content;
+    }
+
+    // Planを更新
+    const plan = await this.prisma.plan.update({
+      where: { id: planId },
+      data: updateData,
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toPlanDto(plan),
+    };
+  }
+
+  /**
+   * Planを削除する（関連コメントもカスケード削除）
+   */
+  async remove(planId: number, user: AuthenticatedUser): Promise<PlanDeleteResponseDto> {
+    // Planのアクセス権と編集可能状態チェック
+    await this.checkPlanAccess(planId, user, true);
+
+    // Planを削除（コメントはDBのカスケード削除で自動削除）
+    await this.prisma.plan.delete({
+      where: { id: planId },
+    });
+
+    return {
+      success: true,
+      message: "計画を削除しました",
+    };
+  }
+}

--- a/src/problems/dto/create-problem.dto.ts
+++ b/src/problems/dto/create-problem.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty, IsString } from "class-validator";
+
+/**
+ * 優先度enum
+ */
+export enum PriorityEnum {
+  HIGH = "high",
+  MEDIUM = "medium",
+  LOW = "low",
+}
+
+/**
+ * Problem作成DTO
+ */
+export class CreateProblemDto {
+  @ApiProperty({
+    description: "課題・相談内容",
+    example: "競合他社が価格攻勢をかけてきている",
+  })
+  @IsString({ message: "内容は文字列で指定してください" })
+  @IsNotEmpty({ message: "内容は必須です" })
+  content!: string;
+
+  @ApiProperty({
+    description: "優先度",
+    enum: PriorityEnum,
+    example: "high",
+  })
+  @IsEnum(PriorityEnum, { message: "優先度は high, medium, low のいずれかを指定してください" })
+  priority!: PriorityEnum;
+}

--- a/src/problems/dto/index.ts
+++ b/src/problems/dto/index.ts
@@ -1,0 +1,3 @@
+export * from "./create-problem.dto";
+export * from "./update-problem.dto";
+export * from "./problem-response.dto";

--- a/src/problems/dto/problem-response.dto.ts
+++ b/src/problems/dto/problem-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { PriorityEnum } from "./create-problem.dto";
+
+/**
+ * ProblemDTO
+ */
+export class ProblemDto {
+  @ApiProperty({ description: "Problem ID", example: 1 })
+  problem_id!: number;
+
+  @ApiProperty({ description: "課題・相談内容", example: "競合他社が価格攻勢をかけてきている" })
+  content!: string;
+
+  @ApiProperty({
+    description: "優先度",
+    enum: PriorityEnum,
+    example: "high",
+  })
+  priority!: string;
+
+  @ApiProperty({ description: "コメント数", example: 2 })
+  comment_count!: number;
+
+  @ApiProperty({ description: "作成日時", example: "2026-02-15T09:00:00.000Z" })
+  created_at!: string;
+
+  @ApiProperty({ description: "更新日時", example: "2026-02-15T09:00:00.000Z" })
+  updated_at!: string;
+}
+
+/**
+ * Problem一覧レスポンスDTO
+ */
+export class ProblemListResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Problem一覧", type: [ProblemDto] })
+  data!: ProblemDto[];
+}
+
+/**
+ * Problem詳細レスポンスDTO
+ */
+export class ProblemDetailResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "Problem", type: ProblemDto })
+  data!: ProblemDto;
+}
+
+/**
+ * Problem削除レスポンスDTO
+ */
+export class ProblemDeleteResponseDto {
+  @ApiProperty({ description: "成功フラグ", example: true })
+  success!: boolean;
+
+  @ApiProperty({ description: "メッセージ", example: "課題・相談を削除しました" })
+  message!: string;
+}

--- a/src/problems/dto/update-problem.dto.ts
+++ b/src/problems/dto/update-problem.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsEnum, IsOptional, IsString } from "class-validator";
+import { PriorityEnum } from "./create-problem.dto";
+
+/**
+ * Problem更新DTO
+ */
+export class UpdateProblemDto {
+  @ApiPropertyOptional({
+    description: "課題・相談内容",
+    example: "競合他社が価格攻勢をかけてきている",
+  })
+  @IsOptional()
+  @IsString({ message: "内容は文字列で指定してください" })
+  content?: string;
+
+  @ApiPropertyOptional({
+    description: "優先度",
+    enum: PriorityEnum,
+    example: "high",
+  })
+  @IsOptional()
+  @IsEnum(PriorityEnum, { message: "優先度は high, medium, low のいずれかを指定してください" })
+  priority?: PriorityEnum;
+}

--- a/src/problems/index.ts
+++ b/src/problems/index.ts
@@ -1,0 +1,3 @@
+export * from "./problems.module";
+export * from "./problems.service";
+export * from "./problems.controller";

--- a/src/problems/problems.controller.spec.ts
+++ b/src/problems/problems.controller.spec.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProblemsController } from "./problems.controller";
+import type { ProblemsService } from "./problems.service";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import { PriorityEnum } from "./dto";
+
+describe("ProblemsController", () => {
+  let problemsController: ProblemsController;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockProblemsService = {
+    findAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    problemsController = new ProblemsController(mockProblemsService as unknown as ProblemsService);
+  });
+
+  describe("findAll", () => {
+    it("Problem一覧を取得できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: [
+          {
+            problem_id: 1,
+            content: "競合他社が価格攻勢をかけてきている",
+            priority: "high",
+            comment_count: 2,
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      };
+
+      mockProblemsService.findAll.mockResolvedValue(mockResponse);
+
+      const result = await problemsController.findAll(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockProblemsService.findAll).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+
+  describe("create", () => {
+    it("PRB-001: Problemを登録できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          problem_id: 1,
+          content: "競合他社が価格攻勢をかけてきている",
+          priority: "high",
+          comment_count: 0,
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T09:00:00.000Z",
+        },
+      };
+
+      mockProblemsService.create.mockResolvedValue(mockResponse);
+
+      const dto = {
+        content: "競合他社が価格攻勢をかけてきている",
+        priority: PriorityEnum.HIGH,
+      };
+
+      const result = await problemsController.create(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockProblemsService.create).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("update", () => {
+    it("PRB-010: Problemを更新できる", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          problem_id: 1,
+          content: "更新された課題内容",
+          priority: "low",
+          comment_count: 1,
+          created_at: "2026-02-15T09:00:00.000Z",
+          updated_at: "2026-02-15T15:00:00.000Z",
+        },
+      };
+
+      mockProblemsService.update.mockResolvedValue(mockResponse);
+
+      const dto = {
+        content: "更新された課題内容",
+        priority: PriorityEnum.LOW,
+      };
+
+      const result = await problemsController.update(1, dto, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockProblemsService.update).toHaveBeenCalledWith(1, dto, mockSalesUser);
+    });
+  });
+
+  describe("remove", () => {
+    it("PRB-012: Problemを削除できる", async () => {
+      const mockResponse = {
+        success: true,
+        message: "課題・相談を削除しました",
+      };
+
+      mockProblemsService.remove.mockResolvedValue(mockResponse);
+
+      const result = await problemsController.remove(1, { user: mockSalesUser });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockProblemsService.remove).toHaveBeenCalledWith(1, mockSalesUser);
+    });
+  });
+});

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -1,0 +1,191 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  Request,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { ProblemsService } from "./problems.service";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS validation requires runtime class reference
+import {
+  CreateProblemDto,
+  UpdateProblemDto,
+  ProblemListResponseDto,
+  ProblemDetailResponseDto,
+  ProblemDeleteResponseDto,
+} from "./dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+
+@ApiTags("課題・相談")
+@Controller()
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class ProblemsController {
+  constructor(private readonly problemsService: ProblemsService) {}
+
+  /**
+   * Problem一覧取得
+   */
+  @Get("reports/:reportId/problems")
+  @ApiOperation({
+    summary: "課題・相談一覧取得",
+    description: "指定した日報の課題・相談一覧を取得する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "取得成功",
+    type: ProblemListResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報にアクセス）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  async findAll(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<ProblemListResponseDto> {
+    return this.problemsService.findAll(reportId, req.user);
+  }
+
+  /**
+   * Problem登録
+   */
+  @Post("reports/:reportId/problems")
+  @ApiOperation({
+    summary: "課題・相談登録",
+    description: "指定した日報に課題・相談を登録する。",
+  })
+  @ApiParam({
+    name: "reportId",
+    description: "日報ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 201,
+    description: "登録成功",
+    type: ProblemDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の日報への追加、または提出済み日報への追加）",
+  })
+  @ApiNotFoundResponse({
+    description: "日報が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー（必須項目未入力等）",
+  })
+  async create(
+    @Param("reportId", ParseIntPipe) reportId: number,
+    @Body() dto: CreateProblemDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<ProblemDetailResponseDto> {
+    return this.problemsService.create(reportId, dto, req.user);
+  }
+
+  /**
+   * Problem更新
+   */
+  @Put("problems/:id")
+  @ApiOperation({
+    summary: "課題・相談更新",
+    description: "指定した課題・相談を更新する。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Problem ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "更新成功",
+    type: ProblemDetailResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の課題・相談の更新、または提出済み日報の課題・相談の更新）",
+  })
+  @ApiNotFoundResponse({
+    description: "課題・相談が見つからない",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "バリデーションエラー",
+  })
+  async update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: UpdateProblemDto,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<ProblemDetailResponseDto> {
+    return this.problemsService.update(id, dto, req.user);
+  }
+
+  /**
+   * Problem削除
+   */
+  @Delete("problems/:id")
+  @ApiOperation({
+    summary: "課題・相談削除",
+    description: "指定した課題・相談を削除する。関連するコメントも削除される。",
+  })
+  @ApiParam({
+    name: "id",
+    description: "Problem ID",
+    type: Number,
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: "削除成功",
+    type: ProblemDeleteResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "認証エラー（トークンがない、または無効）",
+  })
+  @ApiForbiddenResponse({
+    description: "権限エラー（他人の課題・相談の削除、または提出済み日報の課題・相談の削除）",
+  })
+  @ApiNotFoundResponse({
+    description: "課題・相談が見つからない",
+  })
+  async remove(
+    @Param("id", ParseIntPipe) id: number,
+    @Request() req: { user: AuthenticatedUser }
+  ): Promise<ProblemDeleteResponseDto> {
+    return this.problemsService.remove(id, req.user);
+  }
+}

--- a/src/problems/problems.module.ts
+++ b/src/problems/problems.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { ProblemsController } from "./problems.controller";
+import { ProblemsService } from "./problems.service";
+
+@Module({
+  controllers: [ProblemsController],
+  providers: [ProblemsService],
+  exports: [ProblemsService],
+})
+export class ProblemsModule {}

--- a/src/problems/problems.service.spec.ts
+++ b/src/problems/problems.service.spec.ts
@@ -1,0 +1,366 @@
+import { NotFoundException, ForbiddenException } from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProblemsService } from "./problems.service";
+import type { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import type { Priority } from "@prisma/client";
+import { PriorityEnum } from "./dto";
+
+describe("ProblemsService", () => {
+  let problemsService: ProblemsService;
+
+  const mockSalesUser: AuthenticatedUser = {
+    id: 1,
+    email: "tanaka@example.com",
+    name: "田中 太郎",
+    role: "sales" as const,
+  };
+
+  const mockAdminUser: AuthenticatedUser = {
+    id: 99,
+    email: "admin@example.com",
+    name: "Admin",
+    role: "admin" as const,
+  };
+
+  const mockPrismaService = {
+    dailyReport: {
+      findUnique: vi.fn(),
+    },
+    problem: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    problemsService = new ProblemsService(mockPrismaService as unknown as PrismaService);
+  });
+
+  describe("findAll", () => {
+    it("日報のProblem一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockProblems = [
+        {
+          id: 1,
+          content: "競合他社が価格攻勢をかけてきている",
+          priority: "high" as Priority,
+          createdAt: new Date("2026-02-15T09:00:00Z"),
+          updatedAt: new Date("2026-02-15T09:00:00Z"),
+          _count: { comments: 2 },
+        },
+      ];
+
+      mockPrismaService.problem.findMany.mockResolvedValue(mockProblems);
+
+      const result = await problemsService.findAll(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        data: [
+          {
+            problem_id: 1,
+            content: "競合他社が価格攻勢をかけてきている",
+            priority: "high",
+            comment_count: 2,
+            created_at: "2026-02-15T09:00:00.000Z",
+            updated_at: "2026-02-15T09:00:00.000Z",
+          },
+        ],
+      });
+    });
+
+    it("存在しない日報IDで404エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue(null);
+
+      await expect(problemsService.findAll(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it("他人の日報へのアクセスで403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(problemsService.findAll(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("create", () => {
+    // PRB-001: 正常系 - Problemを登録できること
+    it("PRB-001: Problemを登録できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockCreatedProblem = {
+        id: 1,
+        content: "競合他社が価格攻勢をかけてきている",
+        priority: "high" as Priority,
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        _count: { comments: 0 },
+      };
+
+      mockPrismaService.problem.create.mockResolvedValue(mockCreatedProblem);
+
+      const result = await problemsService.create(
+        1,
+        {
+          content: "競合他社が価格攻勢をかけてきている",
+          priority: PriorityEnum.HIGH,
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.problem_id).toBe(1);
+      expect(result.data.priority).toBe("high");
+    });
+
+    // PRB-002: 異常系 - 内容未指定で422エラー（バリデーションはDTOで行うため省略）
+
+    // PRB-003: 異常系 - 優先度未指定で422エラー（バリデーションはDTOで行うため省略）
+
+    // PRB-004: 異常系 - 提出済み日報への追加で403エラー
+    it("PRB-004: 提出済み日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "submitted",
+      });
+
+      await expect(
+        problemsService.create(
+          1,
+          {
+            content: "課題内容",
+            priority: PriorityEnum.HIGH,
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // PRB-005: 異常系 - 他人の日報への追加で403エラー
+    it("PRB-005: 他人の日報への追加で403エラー", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 999,
+        status: "draft",
+      });
+
+      await expect(
+        problemsService.create(
+          1,
+          {
+            content: "課題内容",
+            priority: PriorityEnum.MEDIUM,
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe("update", () => {
+    // PRB-010: 正常系 - Problemを更新できること
+    it("PRB-010: Problemを更新できる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      const mockUpdatedProblem = {
+        id: 1,
+        content: "更新された課題内容",
+        priority: "low" as Priority,
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T15:00:00Z"),
+        _count: { comments: 1 },
+      };
+
+      mockPrismaService.problem.update.mockResolvedValue(mockUpdatedProblem);
+
+      const result = await problemsService.update(
+        1,
+        {
+          content: "更新された課題内容",
+          priority: PriorityEnum.LOW,
+        },
+        mockSalesUser
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.content).toBe("更新された課題内容");
+      expect(result.data.priority).toBe("low");
+    });
+
+    // PRB-011: 異常系 - 提出済み日報のProblem更新で403エラー
+    it("PRB-011: 提出済み日報のProblem更新で403エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(
+        problemsService.update(
+          1,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("他人のProblem更新で403エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(
+        problemsService.update(
+          1,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しないProblemの更新で404エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue(null);
+
+      await expect(
+        problemsService.update(
+          999,
+          {
+            content: "更新内容",
+          },
+          mockSalesUser
+        )
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("remove", () => {
+    // PRB-012: 正常系 - Problemを削除できること
+    it("PRB-012: Problemを削除できる", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "draft",
+        },
+      });
+
+      mockPrismaService.problem.delete.mockResolvedValue({ id: 1 });
+
+      const result = await problemsService.remove(1, mockSalesUser);
+
+      expect(result).toEqual({
+        success: true,
+        message: "課題・相談を削除しました",
+      });
+    });
+
+    it("提出済み日報のProblem削除で403エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 1,
+          status: "submitted",
+        },
+      });
+
+      await expect(problemsService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("他人のProblem削除で403エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue({
+        id: 1,
+        reportId: 1,
+        dailyReport: {
+          salespersonId: 999,
+          status: "draft",
+        },
+      });
+
+      await expect(problemsService.remove(1, mockSalesUser)).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しないProblemの削除で404エラー", async () => {
+      mockPrismaService.problem.findUnique.mockResolvedValue(null);
+
+      await expect(problemsService.remove(999, mockSalesUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("admin access", () => {
+    it("adminは他人の日報のProblem一覧を取得できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1, // 他人のID
+        status: "draft",
+      });
+
+      mockPrismaService.problem.findMany.mockResolvedValue([]);
+
+      const result = await problemsService.findAll(1, mockAdminUser);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("adminは他人の日報にProblemを追加できる", async () => {
+      mockPrismaService.dailyReport.findUnique.mockResolvedValue({
+        salespersonId: 1,
+        status: "draft",
+      });
+
+      const mockCreatedProblem = {
+        id: 1,
+        content: "課題内容",
+        priority: "medium" as Priority,
+        createdAt: new Date("2026-02-15T09:00:00Z"),
+        updatedAt: new Date("2026-02-15T09:00:00Z"),
+        _count: { comments: 0 },
+      };
+
+      mockPrismaService.problem.create.mockResolvedValue(mockCreatedProblem);
+
+      const result = await problemsService.create(
+        1,
+        {
+          content: "課題内容",
+          priority: PriorityEnum.MEDIUM,
+        },
+        mockAdminUser
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/problems/problems.service.ts
+++ b/src/problems/problems.service.ts
@@ -1,0 +1,266 @@
+import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
+import type { Priority } from "@prisma/client";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- NestJS DI requires runtime class reference
+import { PrismaService } from "../prisma";
+import type { AuthenticatedUser } from "../auth/strategies/jwt.strategy";
+import type {
+  CreateProblemDto,
+  UpdateProblemDto,
+  ProblemListResponseDto,
+  ProblemDetailResponseDto,
+  ProblemDeleteResponseDto,
+  ProblemDto,
+} from "./dto";
+
+@Injectable()
+export class ProblemsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * ProblemデータをDTOに変換
+   */
+  private toProblemDto(problem: {
+    id: number;
+    content: string;
+    priority: Priority;
+    createdAt: Date;
+    updatedAt: Date;
+    _count: { comments: number };
+  }): ProblemDto {
+    return {
+      problem_id: problem.id,
+      content: problem.content,
+      priority: problem.priority,
+      comment_count: problem._count.comments,
+      created_at: problem.createdAt.toISOString(),
+      updated_at: problem.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 日報の所有権と編集可能状態をチェック
+   */
+  private async checkReportAccess(
+    reportId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{ salespersonId: number; status: string }> {
+    const report = await this.prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      select: {
+        salespersonId: true,
+        status: true,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "日報が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && report.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この日報にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && report.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return report;
+  }
+
+  /**
+   * Problemの所有権チェック
+   */
+  private async checkProblemAccess(
+    problemId: number,
+    user: AuthenticatedUser,
+    requireEditable: boolean = false
+  ): Promise<{
+    id: number;
+    reportId: number;
+    report: { salespersonId: number; status: string };
+  }> {
+    const problem = await this.prisma.problem.findUnique({
+      where: { id: problemId },
+      select: {
+        id: true,
+        reportId: true,
+        dailyReport: {
+          select: {
+            salespersonId: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    if (!problem) {
+      throw new NotFoundException({
+        code: "NOT_FOUND",
+        message: "課題・相談が見つかりません",
+      });
+    }
+
+    // 所有権チェック（adminは全員の日報にアクセス可能）
+    if (user.role !== "admin" && problem.dailyReport.salespersonId !== user.id) {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "この課題・相談にアクセスする権限がありません",
+      });
+    }
+
+    // 編集可能状態チェック
+    if (requireEditable && problem.dailyReport.status === "submitted") {
+      throw new ForbiddenException({
+        code: "FORBIDDEN",
+        message: "提出済みの日報は編集できません",
+      });
+    }
+
+    return {
+      id: problem.id,
+      reportId: problem.reportId,
+      report: problem.dailyReport,
+    };
+  }
+
+  /**
+   * Problem一覧を取得する
+   */
+  async findAll(reportId: number, user: AuthenticatedUser): Promise<ProblemListResponseDto> {
+    // 日報のアクセス権チェック
+    await this.checkReportAccess(reportId, user);
+
+    // Problemを取得
+    const problems = await this.prisma.problem.findMany({
+      where: { reportId },
+      select: {
+        id: true,
+        content: true,
+        priority: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+      orderBy: { id: "asc" },
+    });
+
+    return {
+      success: true,
+      data: problems.map((p) => this.toProblemDto(p)),
+    };
+  }
+
+  /**
+   * Problemを作成する
+   */
+  async create(
+    reportId: number,
+    dto: CreateProblemDto,
+    user: AuthenticatedUser
+  ): Promise<ProblemDetailResponseDto> {
+    // 日報のアクセス権と編集可能状態チェック
+    await this.checkReportAccess(reportId, user, true);
+
+    // Problemを作成
+    const problem = await this.prisma.problem.create({
+      data: {
+        reportId,
+        content: dto.content,
+        priority: dto.priority as Priority,
+      },
+      select: {
+        id: true,
+        content: true,
+        priority: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toProblemDto(problem),
+    };
+  }
+
+  /**
+   * Problemを更新する
+   */
+  async update(
+    problemId: number,
+    dto: UpdateProblemDto,
+    user: AuthenticatedUser
+  ): Promise<ProblemDetailResponseDto> {
+    // Problemのアクセス権と編集可能状態チェック
+    await this.checkProblemAccess(problemId, user, true);
+
+    // 更新データの構築
+    const updateData: {
+      content?: string;
+      priority?: Priority;
+    } = {};
+
+    if (dto.content !== undefined) {
+      updateData.content = dto.content;
+    }
+    if (dto.priority !== undefined) {
+      updateData.priority = dto.priority as Priority;
+    }
+
+    // Problemを更新
+    const problem = await this.prisma.problem.update({
+      where: { id: problemId },
+      data: updateData,
+      select: {
+        id: true,
+        content: true,
+        priority: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: {
+          select: { comments: true },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: this.toProblemDto(problem),
+    };
+  }
+
+  /**
+   * Problemを削除する（関連コメントもカスケード削除）
+   */
+  async remove(problemId: number, user: AuthenticatedUser): Promise<ProblemDeleteResponseDto> {
+    // Problemのアクセス権と編集可能状態チェック
+    await this.checkProblemAccess(problemId, user, true);
+
+    // Problemを削除（コメントはDBのカスケード削除で自動削除）
+    await this.prisma.problem.delete({
+      where: { id: problemId },
+    });
+
+    return {
+      success: true,
+      message: "課題・相談を削除しました",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- コメントAPIの実装（GET/POST /problems/{id}/comments, GET/POST /plans/{id}/comments, DELETE /comments/{id}）
- ポリモーフィックコメント（Problem/Plan両方に対応）
- ロールベース権限制御（sales: 閲覧のみ、manager: 部下の日報へ投稿可能、admin: 全アクセス可能）
- ユニットテスト25件追加（CMT-001~CMT-021のテストケースカバー）

## Test plan
- [x] `npm run test` - 全219件のテストが通過
- [x] `npm run lint` - エラーなし（警告のみ）
- [x] `npm run typecheck` - 型チェック通過

## Related Issues
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Comments module enabling users to comment on problems and plans with role-based access control and permission validation
  * Added Plans module for creating and managing plans tied to daily reports with edit state checks
  * Added Problems module for tracking and prioritizing issues in daily reports with full CRUD operations

* **Tests**
  * Comprehensive unit test coverage for Comments, Plans, and Problems modules including authorization and access control validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->